### PR TITLE
ASIO integration

### DIFF
--- a/doc/installation.dox
+++ b/doc/installation.dox
@@ -49,7 +49,7 @@ Continuable is a header-only library with one required header-only dependency:
     erasure wrapper to convert a \ref continuable_base into a \ref continuable.
 
 Additionally GTest is required as optional dependency for the asynchronous
-unit testing macros defined in `continuable/continuable-testing.hpp`
+unit testing macros defined in `continuable/support/gtest.hpp`
 if those are used:
 
   - [google/googletest](https://github.com/google/googletest) is used as

--- a/examples/example-asio/CMakeLists.txt
+++ b/examples/example-asio/CMakeLists.txt
@@ -1,14 +1,20 @@
+add_library(asio-example-deps INTERFACE)
+
+target_include_directories(asio-example-deps
+  INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR})
+
+target_link_libraries(asio-example-deps
+  INTERFACE
+    asio
+    continuable)
+
 add_executable(example-asio
     ${CMAKE_CURRENT_LIST_DIR}/example-asio.cpp)
 
-target_include_directories(example-asio
-  PRIVATE
-    ${CMAKE_CURRENT_LIST_DIR})
-
 target_link_libraries(example-asio
   PRIVATE
-    asio
-    continuable)
+    asio-example-deps)
 
 target_compile_definitions(example-asio
   PUBLIC

--- a/examples/example-asio/CMakeLists.txt
+++ b/examples/example-asio/CMakeLists.txt
@@ -19,3 +19,10 @@ target_link_libraries(example-asio
 target_compile_definitions(example-asio
   PUBLIC
     -DCONTINUABLE_WITH_NO_EXCEPTIONS)
+
+add_executable(example-asio-integration
+    ${CMAKE_CURRENT_LIST_DIR}/example-asio-integration.cpp)
+
+target_link_libraries(example-asio-integration
+  PRIVATE
+    asio-example-deps)

--- a/examples/example-asio/example-asio-integration.cpp
+++ b/examples/example-asio/example-asio-integration.cpp
@@ -1,0 +1,96 @@
+
+/*
+
+                        /~` _  _ _|_. _     _ |_ | _
+                        \_,(_)| | | || ||_|(_||_)|(/_
+
+                    https://github.com/Naios/continuable
+                                   v4.0.0
+
+  Copyright(c) 2015 - 2019 Denis Blank <denis.blank at outlook dot com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files(the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions :
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+**/
+
+#define ASIO_HAS_RETURN_TYPE_DEDUCTION
+
+#include <continuable/continuable.hpp>
+#include <continuable/support/asio.hpp>
+
+#include <asio.hpp>
+
+// Queries the NIST daytime service and prints the current date and time
+void daytime_service();
+
+// Checks that a cancelled timer async_wait fails with
+// `asio::error::operation_aborted`
+void cancelled_async_wait();
+
+int main(int, char**) {
+  daytime_service();
+  cancelled_async_wait();
+
+  return 0;
+}
+
+void daytime_service() {
+  using asio::ip::tcp;
+
+  asio::io_context ioc(1);
+  tcp::resolver resolver(ioc);
+  tcp::socket socket(ioc);
+  std::string buf;
+
+  resolver.async_resolve("time.nist.gov", "daytime", asio::use_cti)
+      .then([&socket](tcp::resolver::results_type endpoints) {
+        return asio::async_connect(socket, endpoints, asio::use_cti);
+      })
+      .then([&socket, &buf] {
+        return asio::async_read_until(socket, asio::dynamic_buffer(buf), '\n',
+                                      asio::use_cti);
+      })
+      .then([&buf](std::size_t) { puts(buf.data()); })
+      .fail([](cti::exception_t e) { std::rethrow_exception(e); });
+
+  ioc.run();
+}
+
+void cancelled_async_wait() {
+  asio::io_context ioc(1);
+  asio::steady_timer t(ioc);
+
+  t.expires_after(std::chrono::seconds(999));
+
+  t.async_wait(asio::use_cti)
+      .then([] { throw std::logic_error("Unexpected continuation call"); })
+      .fail([](cti::exception_t ep) {
+        try {
+          std::rethrow_exception(ep);
+        } catch (asio::system_error const& ex) {
+          if (ex.code() == asio::error::operation_aborted) {
+            puts("async_wait failed with expected cancellation error");
+          } else {
+            throw;
+          }
+        }
+      });
+
+  t.cancel_one();
+  ioc.run();
+}

--- a/examples/example-asio/example-asio.cpp
+++ b/examples/example-asio/example-asio.cpp
@@ -5,7 +5,7 @@
                         \_,(_)| | | || ||_|(_||_)|(/_
 
                     https://github.com/Naios/continuable
-                                   v3.0.0
+                                   v4.0.0
 
   Copyright(c) 2015 - 2019 Denis Blank <denis.blank at outlook dot com>
 

--- a/include/continuable/detail/support/asio.hpp
+++ b/include/continuable/detail/support/asio.hpp
@@ -1,0 +1,108 @@
+/*
+
+                        /~` _  _ _|_. _     _ |_ | _
+                        \_,(_)| | | || ||_|(_||_)|(/_
+
+                    https://github.com/Naios/continuable
+                                   v4.0.0
+
+  Copyright(c) 2015 - 2019 Denis Blank <denis.blank at outlook dot com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files(the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions :
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+**/
+
+#ifndef CONTINUABLE_DETAIL_ASIO_HPP_INCLUDED
+#define CONTINUABLE_DETAIL_ASIO_HPP_INCLUDED
+
+#if defined(ASIO_STANDALONE)
+#include <asio/async_result.hpp>
+#include <asio/error_code.hpp>
+#include <asio/system_error.hpp>
+
+#define CTI_ASIO_NAMESPACE_BEGIN namespace asio {
+#define CTI_ASIO_NAMESPACE_END }
+#else
+#include <boost/asio/async_result.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/system/system_error.hpp>
+
+#define CTI_ASIO_NAMESPACE_BEGIN namespace boost { namespace asio {
+#define CTI_ASIO_NAMESPACE_END }}
+#endif
+
+#include <utility>
+
+namespace cti {
+namespace detail {
+namespace asio {
+
+#if defined(ASIO_STANDALONE)
+using error_code_t = ::asio::error_code;
+using exception_t = ::asio::system_error;
+#else
+using error_code_t = ::boost::system::error_code;
+using exception_t = ::boost::system::system_error;
+#endif
+
+// Binds `promise` to the first argument of a continuable resolver, giving it
+// the signature of an ASIO handler.
+template <typename Promise>
+auto promise_resolver_handler(Promise&& promise) noexcept {
+  return [promise = std::forward<Promise>(promise)](
+      error_code_t e, auto&&... args) mutable noexcept {
+    if (e) {
+      promise.set_exception(std::make_exception_ptr(exception_t(std::move(e))));
+    } else {
+      promise.set_value(std::forward<decltype(args)>(args)...);
+    }
+  };
+}
+
+// Type deduction helper for `Result` in `cti::make_continuable<Result>`
+template <typename Signature>
+struct continuable_result;
+
+template <>
+struct continuable_result<void(error_code_t)> {
+  using type = void;
+};
+
+template <>
+struct continuable_result<void(error_code_t const&)>
+    : continuable_result<void(error_code_t)> {};
+
+template <typename T>
+struct continuable_result<void(error_code_t, T)> {
+  using type = T;
+};
+
+template <typename T>
+struct continuable_result<void(error_code_t const&, T)>
+    : continuable_result<void(error_code_t, T)> {};
+
+template <typename Signature>
+using continuable_result_t = typename continuable_result<Signature>::type;
+
+
+
+} // namespace asio
+} // namespace detail
+} // namespace cti
+
+#endif // CONTINUABLE_DETAIL_ASIO_HPP_INCLUDED

--- a/include/continuable/detail/support/asio.hpp
+++ b/include/continuable/detail/support/asio.hpp
@@ -35,15 +35,15 @@
 #include <asio/error_code.hpp>
 #include <asio/system_error.hpp>
 
-#define CTI_ASIO_NAMESPACE_BEGIN namespace asio {
-#define CTI_ASIO_NAMESPACE_END }
+#define CTI_DETAIL_ASIO_NAMESPACE_BEGIN namespace asio {
+#define CTI_DETAIL_ASIO_NAMESPACE_END }
 #else
 #include <boost/asio/async_result.hpp>
 #include <boost/system/error_code.hpp>
 #include <boost/system/system_error.hpp>
 
-#define CTI_ASIO_NAMESPACE_BEGIN namespace boost { namespace asio {
-#define CTI_ASIO_NAMESPACE_END }}
+#define CTI_DETAIL_ASIO_NAMESPACE_BEGIN namespace boost { namespace asio {
+#define CTI_DETAIL_ASIO_NAMESPACE_END }}
 #endif
 
 #include <utility>

--- a/include/continuable/support/asio.hpp
+++ b/include/continuable/support/asio.hpp
@@ -1,0 +1,70 @@
+/*
+
+                        /~` _  _ _|_. _     _ |_ | _
+                        \_,(_)| | | || ||_|(_||_)|(/_
+
+                    https://github.com/Naios/continuable
+                                   v4.0.0
+
+  Copyright(c) 2015 - 2019 Denis Blank <denis.blank at outlook dot com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files(the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions :
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+**/
+
+#ifndef CONTINUABLE_SUPPORT_ASIO_HPP_INCLUDED
+#define CONTINUABLE_SUPPORT_ASIO_HPP_INCLUDED
+
+#include <continuable/continuable-base.hpp>
+#include <continuable/detail/support/asio.hpp>
+#include <continuable/detail/utility/traits.hpp>
+
+CTI_ASIO_NAMESPACE_BEGIN
+
+// Class used to specify an asynchronous operation should return a continuable.
+struct use_cti_t {};
+
+// Special value for instance of `use_cti_t`.
+constexpr use_cti_t use_cti{};
+
+template <typename Signature>
+class async_result<use_cti_t, Signature> {
+public:
+  template <typename Initiation, typename... Args>
+  static auto initiate(Initiation initiation, use_cti_t, Args... args) {
+    return cti::make_continuable<
+        cti::detail::asio::continuable_result_t<Signature>>(
+        [initiation = std::move(initiation),
+         init_args =
+             std::make_tuple(std::move(args)...)](auto&& promise) mutable {
+          cti::detail::traits::unpack(
+              [initiation = std::move(initiation),
+               handler = cti::detail::asio::promise_resolver_handler(
+                   std::forward<decltype(promise)>(promise))](
+                  auto&&... args) mutable {
+                std::move(initiation)(std::move(handler),
+                                      std::forward<decltype(args)>(args)...);
+              },
+              std::move(init_args));
+        });
+  }
+};
+
+CTI_ASIO_NAMESPACE_END
+
+#endif // CONTINUABLE_SUPPORT_ASIO_HPP_INCLUDED

--- a/include/continuable/support/asio.hpp
+++ b/include/continuable/support/asio.hpp
@@ -51,13 +51,7 @@ public:
 #endif
 
   template <typename Initiation, typename... Args>
-  static
-#if defined(CTI_DETAIL_ASIO_HAS_EXPLICIT_RET_TYPE_INTEGRATION)
-      return_type
-#else
-      auto
-#endif
-      initiate(Initiation initiation, use_cti_t, Args... args) {
+  static auto initiate(Initiation initiation, use_cti_t, Args... args) {
     return cti::detail::asio::initiate_make_continuable<Signature>{}(
         [initiation = std::move(initiation),
          init_args =

--- a/include/continuable/support/asio.hpp
+++ b/include/continuable/support/asio.hpp
@@ -34,16 +34,21 @@
 #include <continuable/detail/support/asio.hpp>
 #include <continuable/detail/utility/traits.hpp>
 
+namespace cti {
+
+// Type used as an ASIO completion token to specify an asynchronous operation
+// should return a continuable.
+struct asio_token_t {};
+
+// Special value for instance of `asio_token_t`.
+constexpr asio_token_t asio_token{};
+
+} // namespace cti
+
 CTI_DETAIL_ASIO_NAMESPACE_BEGIN
 
-// Class used to specify an asynchronous operation should return a continuable.
-struct use_cti_t {};
-
-// Special value for instance of `use_cti_t`.
-constexpr use_cti_t use_cti{};
-
 template <typename Signature>
-class async_result<use_cti_t, Signature> {
+class async_result<cti::asio_token_t, Signature> {
 public:
 #if defined(CTI_DETAIL_ASIO_HAS_EXPLICIT_RET_TYPE_INTEGRATION)
   using return_type = typename cti::detail::asio::initiate_make_continuable<
@@ -51,7 +56,7 @@ public:
 #endif
 
   template <typename Initiation, typename... Args>
-  static auto initiate(Initiation initiation, use_cti_t, Args... args) {
+  static auto initiate(Initiation initiation, cti::asio_token_t, Args... args) {
     return cti::detail::asio::initiate_make_continuable<Signature>{}(
         [initiation = std::move(initiation),
          init_args =

--- a/include/continuable/support/asio.hpp
+++ b/include/continuable/support/asio.hpp
@@ -34,7 +34,7 @@
 #include <continuable/detail/support/asio.hpp>
 #include <continuable/detail/utility/traits.hpp>
 
-CTI_ASIO_NAMESPACE_BEGIN
+CTI_DETAIL_ASIO_NAMESPACE_BEGIN
 
 // Class used to specify an asynchronous operation should return a continuable.
 struct use_cti_t {};
@@ -65,6 +65,9 @@ public:
   }
 };
 
-CTI_ASIO_NAMESPACE_END
+CTI_DETAIL_ASIO_NAMESPACE_END
+
+#undef CTI_DETAIL_ASIO_NAMESPACE_BEGIN
+#undef CTI_DETAIL_ASIO_NAMESPACE_END
 
 #endif // CONTINUABLE_SUPPORT_ASIO_HPP_INCLUDED

--- a/include/continuable/support/gtest.hpp
+++ b/include/continuable/support/gtest.hpp
@@ -28,8 +28,8 @@
   SOFTWARE.
 **/
 
-#ifndef CONTINUABLE_TESTING_HPP_INCLUDED
-#define CONTINUABLE_TESTING_HPP_INCLUDED
+#ifndef CONTINUABLE_GTEST_HPP_INCLUDED
+#define CONTINUABLE_GTEST_HPP_INCLUDED
 
 #include <continuable/detail/other/testing.hpp>
 #include <continuable/detail/utility/traits.hpp>
@@ -169,4 +169,4 @@
 
 /// \}
 
-#endif // CONTINUABLE_TESTING_HPP_INCLUDED
+#endif // CONTINUABLE_GTEST_HPP_INCLUDED

--- a/include/continuable/support/gtest.hpp
+++ b/include/continuable/support/gtest.hpp
@@ -28,8 +28,8 @@
   SOFTWARE.
 **/
 
-#ifndef CONTINUABLE_GTEST_HPP_INCLUDED
-#define CONTINUABLE_GTEST_HPP_INCLUDED
+#ifndef CONTINUABLE_SUPPORT_GTEST_HPP_INCLUDED
+#define CONTINUABLE_SUPPORT_GTEST_HPP_INCLUDED
 
 #include <continuable/detail/other/testing.hpp>
 #include <continuable/detail/utility/traits.hpp>
@@ -169,4 +169,4 @@
 
 /// \}
 
-#endif // CONTINUABLE_GTEST_HPP_INCLUDED
+#endif // CONTINUABLE_SUPPORT_GTEST_HPP_INCLUDED

--- a/test/unit-test/test-continuable.hpp
+++ b/test/unit-test/test-continuable.hpp
@@ -31,8 +31,8 @@
 #include <functional>
 
 #include <continuable/continuable-base.hpp>
-#include <continuable/continuable-testing.hpp>
 #include <continuable/continuable.hpp>
+#include <continuable/support/gtest.hpp>
 #include <string>
 
 using cti::detail::identity;


### PR DESCRIPTION
@Naios <!-- This is required so I get notified properly -->


Here is the preliminary PR for #27 . Opening it now so we can discuss/improve with code review features, but it is not ready to merge. The main blockers are
- the release of Boost 1.72
- the release of standalone ASIO 1.15 (I believe)

This is required of course for the new form of `async_result`, but also to get rid of a bug workaround for MSVC detection of `auto` return type support (workaround [here](https://github.com/cstratopoulos/continuable/blob/feature/asio-support/examples/example-asio/example-asio-integration.cpp#L31), bug report [here](https://lists.boost.org/Archives/boost/2019/11/247470.php))

However there are other things I wanted to flag for your approval or discussion, mostly related to error handling.

1. Note the current example calls [`std::make_exception_ptr(asio::error_code)`](https://github.com/Naios/continuable/blob/master/examples/example-asio/example-asio.cpp#L51). From the `std::make_exception_ptr` [documentation](https://en.cppreference.com/w/cpp/error/make_exception_ptr), this suggests that such errors will only be caught in a `.fail` handler if the user does `catch(asio::error_code const&)`. However I think this is not standard, as the usual approach for moving from error codes to exceptions would be to `throw`/`catch` an `asio::system_error` constructed from an `asio::error_code`. If my assessment is correct I can amend the line linked above to do `make_exception_ptr(system_error(e))`. This is also why I added the `cancelled_async_wait` example, to be sure exceptions can be caught as expected. 

2. Consequently from 1., the distribution-specific detail code has [some logic](https://github.com/cstratopoulos/continuable/blob/feature/asio-support/include/continuable/detail/support/asio.hpp#L55) to establish the pair `exception_t` and `error_code_t` such that the former is constructible from the latter. This is a divergence from our discussion in #27 where we thought all mention of the `error_code` type could be elided by having a lambda handler with an `auto ec` parameter. Since we're already doing this, I used the `error_code_t` in the [`continuable_result<Signature>` specializations](https://github.com/cstratopoulos/continuable/blob/feature/asio-support/include/continuable/detail/support/asio.hpp#L82). I _think_ this could be done with specializations for `template<typename Error, typename T>`, but this is a bit cleaner and clearer in my opinion. 
     a) This is also why I put `use_cti_t` back in the ASIO namespace, since it fits the convention of other ASIO helper tokens (e.g., `use_future_t`), and we have to muck around in the ASIO namespace anyway. But if you like I can just make it `cti::asio_token_t` or similar!

3. Currently the code only works with exception handling enabled. The standard default for no exceptions is an `std::error_condition`, which will work in the standalone ASIO case (where the error types alias the corresponding `std` types), but not with Boost, which uses Boost.System. I think we can accommodate a couple options. If exceptions are enabled, this fits with the ASIO `use_future_t` error handling mechanism for `std::future` which stores exceptions with `std::promise::set_exception(std::exception_ptr)`. Also, users may want to set `CONTINUABLE_WITH_CUSTOM_ERROR_TYPE` to `asio::error_code` or `boost::system::error_code`, which would also be in line with idiomatic ASIO error handling. Finally, users may have the error type set to `std::error_condition` either by disabling continuable's exceptions, with a custom error type, or they may set it to `boost::system::error_condition`. That one feels maybe less likely/more awkward to me, but it's possible. Anyway to sketch a solution, 
```cpp
// distribution-specific aliases
using error_code_t = ...
using error_cond_t = ...
using exception_t = ...

template<typename Promise>
auto promise_fail_helper(Promise& p, error_code_t ec) 
    -> decltype(p.set_exception(ec)) { p.set_exception(ec); }

template<typename Promise>
auto promise_fail_helper(Promise& p, error_code_t ec)
 -> decltype(p.set_exception(error_cond_t(ec.value(), ec.category()))
{ p.set_exception(error_cond_t(ec.value(), ec.category())) }

template<typename Promise>
auto promise_fail_helper(Promise& p, error_code_t ec) 
    -> decltype(p.set_exception(std::make_exception_ptr(exception_t(ec)))) 
{ p.set_exception(std::make_exception_ptr(exception_t(ec))); }
```
to respect the setting of `CONTINUABLE_WITH_NO_EXCEPTIONS`, the `exception_t` alias and overloads may be guarded with an `#ifdef`. And since `promise_base::set_exception` only accepts `cti::exception_t`, I think there is no overload ambiguity. Anyway let me know your thoughts and I can pursue the sketch solution above if it sounds reasonable to you. 

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [X] Coding style (Clang format was applied)

I applied clang-format while editing the code. As for unit tests, the added example tries to test the robustness of completion handler signatures ( `void(error_code)`, `void(error_code, T)`) and correctness of error handling. This could be added to a unit test with asserts, but I am not sure if this is an approach you want to take. 