### PR TITLE
Issue fix : compile time error on calling when_seq

### DIFF
--- a/include/continuable/detail/connection/connection-seq.hpp
+++ b/include/continuable/detail/connection/connection-seq.hpp
@@ -147,24 +147,24 @@ struct connection_finalizer<connection_strategy_seq_tag> {
   template <typename Connection>
   static auto finalize(Connection&& connection, util::ownership ownership) {
 
-    auto result =
+    auto res =
         aggregated::box_continuables(std::forward<Connection>(connection));
 
-    auto signature = aggregated::hint_of_data<decltype(result)>();
+    auto signature = aggregated::hint_of_data<decltype(res)>();
 
     return base::attorney::create_from(
-        [result = std::move(result)](auto&& callback) mutable {
+        [res = std::move(res)](auto&& callback) mutable {
           // The data from which the visitor is constructed in-place
           using data_t =
               seq::sequential_dispatch_data<std::decay_t<decltype(callback)>,
-                                            std::decay_t<decltype(result)>>;
+                                            std::decay_t<decltype(res)>>;
 
           // The visitor type
           using visitor_t = seq::sequential_dispatch_visitor<data_t>;
 
           traverse_pack_async(async_traverse_in_place_tag<visitor_t>{},
                               data_t{std::forward<decltype(callback)>(callback),
-                                     std::move(result)});
+                                     std::move(res)});
         },
         signature, std::move(ownership));
   }


### PR DESCRIPTION
Fix to the issue https://github.com/Naios/continuable/issues/34

This was causing error on usage of when seq :: "result is not a type name static or enumerator"

@Naios <!-- This is required so I get notified properly -->

<!-- Thank you for your contribution to dot-github! Please replace {Please write here} with your description -->

-----

### What was a problem?

upon using when_seq on MSVC  , an error was thrown stating "result is not a type name static or enumerator". This was because "result" was an ambiguous identifier. The solution of this problem was to rename result to a different identifier used in the lambda (as also seen in connection-all.cpp)

### How this PR fixes the problem?

This PR changes the identifier name "result" being used inside connection_finalizer to "res", which then is non ambiguous with proxy_continuable's result.

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [x] Coding style (Clang format was applied)

### Additional Comments (if any)

{Please write here}
