### PR TITLE
Recover continuable after invoking void fail handlers, s.t. continuab…

### DIFF
--- a/include/continuable/detail/core/base.hpp
+++ b/include/continuable/detail/core/base.hpp
@@ -293,16 +293,6 @@ constexpr void invoke_no_except(T&& callable, Args&&... args) noexcept {
   std::forward<T>(callable)(std::forward<Args>(args)...);
 }
 
-template <typename... Args, typename T>
-void invoke_void_no_except(identity<exception_arg_t, Args...>,
-                           T&& /*callable*/) noexcept {
-  // Don't invoke the next failure handler when being in an exception handler
-}
-template <typename... Args, typename T>
-void invoke_void_no_except(identity<Args...>, T&& callable) noexcept {
-  std::forward<T>(callable)();
-}
-
 template <typename T, typename... Args>
 constexpr auto make_invoker(T&& invoke, identity<Args...>) {
   return invoker<std::decay_t<T>, identity<Args...>>(std::forward<T>(invoke));
@@ -373,9 +363,8 @@ inline auto invoker_of(identity<void>) {
         CONTINUABLE_BLOCK_TRY_BEGIN
           invoke_callback(std::forward<decltype(callback)>(callback),
                           std::forward<decltype(args)>(args)...);
-          invoke_void_no_except(
-              identity<traits::unrefcv_t<decltype(args)>...>{},
-              std::forward<decltype(next_callback)>(next_callback));
+                          
+          invoke_no_except(std::forward<decltype(next_callback)>(next_callback));
         CONTINUABLE_BLOCK_TRY_END
       },
       identity<>{});

--- a/test/unit-test/async/test-continuable-async.cpp
+++ b/test/unit-test/async/test-continuable-async.cpp
@@ -206,3 +206,73 @@ TYPED_TEST(single_dimension_tests, wait_test_issue_46) {
                    
   ASSERT_TRUE(handled);
 }
+
+TYPED_TEST(single_dimension_tests, then_after_nonvoid_fail_handler_invoked) {
+   bool invoked = false;
+   make_exceptional_continuable<int>(supply_test_exception())
+                    .fail([]{
+                      return 1;
+                    })
+                    .then([&]{
+                      EXPECT_FALSE(invoked);
+                      invoked = true;
+                    });
+                    
+   ASSERT_TRUE(invoked);
+ }
+ 
+ TYPED_TEST(single_dimension_tests, then_after_void_fail_handler_invoked) {
+   bool invoked = false;
+   make_exceptional_continuable<void>(supply_test_exception())
+                    .fail([]{
+                      return;
+                    })
+                    .then([&]{
+                      EXPECT_FALSE(invoked);
+                      invoked = true;
+                    });
+                    
+   ASSERT_TRUE(invoked);
+ }
+ 
+ TYPED_TEST(single_dimension_tests, scoped_fail_handler_not_invoked) {
+   bool invoked1 = false;
+   bool invoked2 = false;
+   make_exceptional_continuable<void>(supply_test_exception())
+                    .fail([&]{
+                      EXPECT_FALSE(invoked1);
+                      invoked1 = true;
+                      return;
+                    })
+                    .then([]{
+                      return;
+                    })
+                    .fail([&]{
+                      EXPECT_FALSE(invoked2);
+                      invoked2 = true;
+                    });
+                    
+   ASSERT_TRUE(invoked1);
+   ASSERT_FALSE(invoked2);
+ }
+ 
+ TYPED_TEST(single_dimension_tests, scoped_fail_handler_invoked) {
+   bool invoked1 = false;
+   bool invoked2 = false;
+   make_exceptional_continuable<void>(supply_test_exception())
+                    .fail([&]{
+                      EXPECT_FALSE(invoked1);
+                      invoked1 = true;
+                      return;
+                    })
+                    .then([]{
+                      std::rethrow_exception(supply_test_exception());
+                    })
+                    .fail([&]{
+                      EXPECT_FALSE(invoked2);
+                      invoked2 = true;
+                    });
+                    
+   ASSERT_TRUE(invoked1);
+   ASSERT_TRUE(invoked2);
+ }

--- a/test/unit-test/async/test-continuable-async.cpp
+++ b/test/unit-test/async/test-continuable-async.cpp
@@ -194,3 +194,15 @@ TYPED_TEST(single_dimension_tests, token_remap_ignore) {
 
   ASSERT_TRUE(value.is_value());
 }
+
+TYPED_TEST(single_dimension_tests, wait_test_issue_46) {
+  bool handled = false;
+  make_exceptional_continuable<void>(supply_test_exception())
+                   .fail([&]{
+                       EXPECT_FALSE(handled);
+                       handled = true;
+                   })
+                   .apply(cti::transforms::wait());
+                   
+  ASSERT_TRUE(handled);
+}

--- a/test/unit-test/multi/test-continuable-base-multipath.cpp
+++ b/test/unit-test/multi/test-continuable-base-multipath.cpp
@@ -170,10 +170,12 @@ TYPED_TEST(single_dimension_tests, multipath_exception_is_continuable) {
 
 TYPED_TEST(single_dimension_tests, multipath_exception_is_autocanceled) {
   bool caught = false;
-  ASSERT_ASYNC_INCOMPLETION(
+  ASSERT_ASYNC_COMPLETION(
       this->supply_exception(supply_test_exception()).fail([&](exception_t) {
         EXPECT_FALSE(caught);
         caught = true;
+      }).fail([](exception_t){
+        FAIL();
       }));
   ASSERT_TRUE(caught);
 }


### PR DESCRIPTION
Solve the second case of issue #46.

@Naios <!-- This is required so I get notified properly -->

<!-- Thank you for your contribution to dot-github! Please replace {Please write here} with your description -->

-----

### What was a problem?

In previous revision (modified by 7a5bde32), a continuable is considered completed and will not invoke subsequent handlers after a void fail handler is invoked, as a result it will be blocked if the continuable is waited.

### How this PR fixes the problem?

Invoke subsequent handlers after void fail handlers invoked.

### Check lists (check `x` in `[ ]` of list items)

- [x] Additional Unit Tests were added that test the feature or regression
- [ ] Coding style (Clang format was applied)
