### PR TITLE
Fix incorrect initialization of unsafe_locker

### DIFF
--- a/include/continuable/detail/transforms/wait.hpp
+++ b/include/continuable/detail/transforms/wait.hpp
@@ -74,6 +74,13 @@ using condition_variable_t = std::condition_variable;
 
 template <typename Result>
 struct unsafe_unlocker {
+  explicit unsafe_unlocker(std::atomic_bool* ready, condition_variable_t* cv,
+                           std::mutex* mutex, Result* result)
+    : ready_(ready)
+    , cv_(cv)
+    , mutex_(mutex)
+    , result_(result) {}
+
   unsafe_unlocker(unsafe_unlocker const&) = delete;
   unsafe_unlocker(unsafe_unlocker&&) = default;
   unsafe_unlocker& operator=(unsafe_unlocker const&) = delete;


### PR DESCRIPTION
@Naios <!-- This is required so I get notified properly -->

This fixes #51

-----

### What was a problem?

List-initialization of unsafe_locker class resulted in a compiler error, because 1) it had no constructor matching the arguments, and 2) it had other user-declared constructors, so aggregate initialization was not allowed (per C++20 rules).

References
* https://en.cppreference.com/w/cpp/language/list_initialization
* https://en.cppreference.com/w/cpp/language/aggregate_initialization

### How this PR fixes the problem?

This change fixes the issue by adding an appropriate constructor.

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [x] Coding style (Clang format was applied)

### Additional Comments (if any)

IMO no new unit tests were needed.